### PR TITLE
fix: 繁体中文支持设置无效

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules
 package-lock.json
 yarn.lock
 .npmrc
+dist

--- a/package.json
+++ b/package.json
@@ -5,13 +5,14 @@
   "main": "lib/main.js",
   "license": "MIT",
   "scripts": {
-    "build": "obsidian-plugin build --with-stylesheet ./src/main.ts",
+    "build": "obsidian-plugin build ./src/main.ts && cp styles.css dist",
     "dev": "obsidian-plugin dev src/main.ts",
     "help": "obsidian-plugin --help"
   },
   "devDependencies": {
-    "obsidian": "obsidianmd/obsidian-api",
-    "obsidian-plugin-cli": "^0.4.5",
-    "typescript": "^4.1.5"
+    "builtin-modules": "^3.3.0",
+    "obsidian": "github:obsidianmd/obsidian-api",
+    "obsidian-plugin-cli": "^0.9.0",
+    "typescript": "^4.9.5"
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -434,7 +434,7 @@ class FuzzySettingTab extends PluginSettingTab {
             })
         );
         new Setting(containerEl).setName("繁体支持").addToggle((text) => {
-            text.setValue(this.plugin.settings.showTags).onChange(async (value) => {
+            text.setValue(this.plugin.settings.traditionalChineseSupport).onChange(async (value) => {
                 this.plugin.settings.traditionalChineseSupport = value;
                 await this.plugin.saveSettings();
             });


### PR DESCRIPTION
另外原來的build命令會報錯，順便修了
https://github.com/obsidian-tools/obsidian-tools/issues/72 `obsidian-plugin build -S` 有bug，會把整個`src`目錄放進`dist`裏。我改成了手動複製css