### PR TITLE
fix: 兼容 core plugin `Files` 被禁用

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -227,6 +227,10 @@ class FileExplorerHotkey {
         this.view = this.leaf.view;
     }
     getFiles(): TFile[] {
+        if (this.view === undefined) {
+            // core plugin `Files` is disabled
+            return [];
+        }
         return Array.from((this.view as any).tree.selectedDoms).map((p: { file: TFile }) => p.file);
     }
 }


### PR DESCRIPTION
我禁用了官方的文件树插件，用第三方的。移动文件在这种情况下不起作用