### PR TITLE
feat: 添加「不操作」快捷键选项

### DIFF
--- a/src/modal/fileModal.ts
+++ b/src/modal/fileModal.ts
@@ -275,8 +275,9 @@ export default class FileModal extends FuzzyModal<Item> {
     async onChooseSuggestion(matchData: MatchData, e: MouseEvent | KeyboardEvent) {
         const shiftKey = e.shiftKey;
         if (shiftKey && this.inputEl.value == "") return;
-        this.close();
         const leaf = this.getLeaf(e);
+        if (!leaf) return;
+        this.close();
 
         if (shiftKey) matchData.item.file = await createFile(this.inputEl.value);
         else if (
@@ -298,10 +299,11 @@ export default class FileModal extends FuzzyModal<Item> {
             score: SpecialItemScore.noFoundToCreate,
         });
     }
-    getLeaf(e: MouseEvent | KeyboardEvent): WorkspaceLeaf {
+    getLeaf(e: MouseEvent | KeyboardEvent): WorkspaceLeaf | null {
+        if (e instanceof MouseEvent) return openFileKeyMap["打开"]();
         const modKey = e.ctrlKey || e.metaKey;
         const altKey = e.altKey;
-        let leaf: WorkspaceLeaf;
+        let leaf: WorkspaceLeaf | null;
         let getKey = (key: keyof typeof openFileKeyMap) =>
             openFileKeyMap[this.plugin.settings.file[key]];
         if (modKey && altKey) leaf = getKey("keyCtrlAltEnter")();
@@ -659,7 +661,7 @@ function getFileTagArray(file: TFile): string[] | undefined {
     else if (typeof tags == "object") return undefined;
 }
 
-export const openFileKeyMap: Record<string, () => WorkspaceLeaf> = {
+export const openFileKeyMap: Record<string, () => WorkspaceLeaf | null> = {
     打开: () => {
         const leaf = getMostRecentView().leaf;
         if (leaf.pinned) return app.workspace.getLeaf("tab");
@@ -669,6 +671,7 @@ export const openFileKeyMap: Record<string, () => WorkspaceLeaf> = {
     打开到其他面板: () => getNewOrAdjacentLeaf(),
     打开到新面板: () => app.workspace.getLeaf("split"),
     打开到新窗口: () => app.workspace.getLeaf("window"),
+    不操作: () => null,
 };
 
 function isIgnore(path: string): boolean {

--- a/src/settingTab.ts
+++ b/src/settingTab.ts
@@ -386,10 +386,10 @@ export interface TheSettings {
         searchWithTag: boolean;
         quicklySelectHistoryFiles: boolean;
         quicklySelectHistoryFilesHint: string;
-        keyEnter: keyof typeof openFileKeyMap;
-        keyCtrlEnter: keyof typeof openFileKeyMap;
-        keyAltEnter: keyof typeof openFileKeyMap;
-        keyCtrlAltEnter: keyof typeof openFileKeyMap;
+        keyEnter: string;
+        keyCtrlEnter: string;
+        keyAltEnter: string;
+        keyCtrlAltEnter: string;
     };
     heading: {
         showFirstLevelHeading: boolean;


### PR DESCRIPTION
- 在 Enter/Ctrl+Enter/Alt+Enter/Ctrl+Alt+Enter 功能中增加「不操作」选项
- 选择「不操作」后按下对应快捷键不会关闭弹窗也不会打开文件
- 鼠标点击始终使用「打开」行为，不受快捷键设置影响